### PR TITLE
Feature#22: Adjust date now format

### DIFF
--- a/misc/build.sh
+++ b/misc/build.sh
@@ -16,7 +16,7 @@ build() {
   python3 -m pip install -r requirements.txt
 
   echo "Running code quality tools"
-  pylint --rcfile="./../.pylintrc"
+  pylint --rcfile="./../.pylintrc" src/ test/
 
   echo "Running tests"
   python3 -m unittest

--- a/source/backend/product_prices_collector/child/src/service.py
+++ b/source/backend/product_prices_collector/child/src/service.py
@@ -3,7 +3,7 @@
 import logging
 
 
-from datetime import date
+from datetime import datetime
 from src.lambda_exception import LambdaException
 from src.client import send_request
 from src.repository import put_product
@@ -53,7 +53,7 @@ def _construct_product_price(response):
                 "loyaltyPrice": response_product_price["loyaltyPrice"],
                 "shownPrice": response_product_price["shownPrice"]
             },
-            "date": date.today()
+            "date": datetime.now().date().strftime("%Y-%m-%d")
         }
         return product_price
     except Exception as exception:

--- a/source/backend/product_prices_collector/child/test/test_product_prices_collector_service.py
+++ b/source/backend/product_prices_collector/child/test/test_product_prices_collector_service.py
@@ -1,6 +1,6 @@
 """ Test module """
 
-from datetime import date
+from datetime import datetime
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -66,7 +66,8 @@ class TestProductPricesCollectorService(unittest.TestCase):
                 "loyaltyPrice": 7295,
                 "shownPrice": 7295
             },
-            "date": date.today()
+            # TODO: introduce current datetime provider
+            "date": datetime.now().date().strftime("%Y-%m-%d")
         }
 
         self.assertEqual(actual_response, expected_response)
@@ -118,7 +119,7 @@ class TestProductPricesCollectorService(unittest.TestCase):
                 "loyaltyPrice": 7295,
                 "shownPrice": 7295
             },
-            "date": date.today()
+            "date": datetime.now().date().strftime("%Y-%m-%d")
         }
 
         actual_response = store_product_price(product_price)
@@ -142,7 +143,7 @@ class TestProductPricesCollectorService(unittest.TestCase):
                 "loyaltyPrice": 7295,
                 "shownPrice": 7295
             },
-            "date": date.today()
+            "date": datetime.now().date().strftime("%Y-%m-%d")
         }
 
         actual_response = store_product_price(product_price)


### PR DESCRIPTION
The standard Python's date format was used as a date in one of the DynamoDB columns. However DynamoDB expects ISO8601 as a date or datetime format that allows searching through the period.
Old format: 30-01-2024
New format (ISO8601): 2024-01-30